### PR TITLE
Build real booking flow with Supabase persistence

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,5 @@
 SUPABASE_URL=https://your-project.supabase.co
 SUPABASE_ANON_KEY=your-supabase-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 FRONTEND_URL=http://localhost:3000,https://your-production-frontend-url.vercel.app
 ADMIN_EMAILS=owner@example.com

--- a/backend/server.js
+++ b/backend/server.js
@@ -9,6 +9,7 @@ const PORT = process.env.PORT || 4000;
 const FRONTEND_URL = process.env.FRONTEND_URL || "*";
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const ADMIN_EMAILS = new Set(
   (process.env.ADMIN_EMAILS || "")
     .split(",")
@@ -27,6 +28,18 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
     detectSessionInUrl: false,
   },
 });
+
+const supabaseAdmin = createClient(
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY || SUPABASE_ANON_KEY,
+  {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+      detectSessionInUrl: false,
+    },
+  }
+);
 
 const adminState = {
   emailRecipient: "admin@example.com",
@@ -89,6 +102,62 @@ function isAllowedAdmin(user) {
   return ADMIN_EMAILS.has(normalizedEmail);
 }
 
+function createBookingReference() {
+  const timestamp = Date.now().toString(36).toUpperCase();
+  const randomPart = Math.random().toString(36).slice(2, 6).toUpperCase();
+
+  return `RZ-${timestamp}-${randomPart}`;
+}
+
+function normalizeBookingPayload(payload) {
+  return {
+    categoryId: payload?.categoryId?.trim() || "",
+    categoryName: payload?.categoryName?.trim() || "",
+    packageId: payload?.packageId?.trim() || "",
+    packageName: payload?.packageName?.trim() || "",
+    packagePrice: Number(payload?.packagePrice || 0),
+    bookingDate: payload?.bookingDate?.trim() || "",
+    bookingTime: payload?.bookingTime?.trim() || "",
+    firstName: payload?.firstName?.trim() || "",
+    lastName: payload?.lastName?.trim() || "",
+    email: payload?.email?.trim().toLowerCase() || "",
+    phone: payload?.phone?.trim() || "",
+    vehicleDetails: payload?.vehicleDetails?.trim() || "",
+    notes: payload?.notes?.trim() || "",
+  };
+}
+
+function validateBookingPayload(payload) {
+  const requiredFields = [
+    ["categoryId", "Service category is required."],
+    ["categoryName", "Service category label is required."],
+    ["packageId", "Package selection is required."],
+    ["packageName", "Package label is required."],
+    ["bookingDate", "Booking date is required."],
+    ["bookingTime", "Booking time is required."],
+    ["firstName", "First name is required."],
+    ["lastName", "Last name is required."],
+    ["email", "Email is required."],
+    ["phone", "Phone is required."],
+  ];
+
+  for (const [field, message] of requiredFields) {
+    if (!payload[field]) {
+      return message;
+    }
+  }
+
+  if (!/^\S+@\S+\.\S+$/.test(payload.email)) {
+    return "Enter a valid email address.";
+  }
+
+  if (!Number.isFinite(payload.packagePrice) || payload.packagePrice < 0) {
+    return "Package price must be a valid number.";
+  }
+
+  return null;
+}
+
 async function requireAdmin(req, res, next) {
   const accessToken = normalizeAuthToken(req.headers.authorization);
 
@@ -113,6 +182,54 @@ async function requireAdmin(req, res, next) {
 
 app.get("/health", (req, res) => {
   res.json({ ok: true, service: "royalz-render-backend" });
+});
+
+app.post("/api/bookings", async (req, res) => {
+  const booking = normalizeBookingPayload(req.body || {});
+  const validationError = validateBookingPayload(booking);
+
+  if (validationError) {
+    return res.status(400).json({ error: validationError });
+  }
+
+  const reference = createBookingReference();
+
+  const insertPayload = {
+    reference,
+    service_category_id: booking.categoryId,
+    service_category_name: booking.categoryName,
+    package_id: booking.packageId,
+    package_name: booking.packageName,
+    package_price: booking.packagePrice,
+    booking_date: booking.bookingDate,
+    booking_time: booking.bookingTime,
+    customer_first_name: booking.firstName,
+    customer_last_name: booking.lastName,
+    customer_email: booking.email,
+    customer_phone: booking.phone,
+    vehicle_details: booking.vehicleDetails || null,
+    notes: booking.notes || null,
+    status: "pending",
+  };
+
+  const { data, error } = await supabaseAdmin
+    .from("bookings")
+    .insert(insertPayload)
+    .select("id, reference, status, booking_date, booking_time, package_name")
+    .single();
+
+  if (error) {
+    console.error("Unable to save booking.", error);
+    return res.status(500).json({
+      error:
+        "Unable to save the booking. Check the Supabase bookings table and backend service role configuration.",
+    });
+  }
+
+  return res.status(201).json({
+    message: "Booking request saved successfully.",
+    booking: data,
+  });
 });
 
 app.get("/api/auth/session", requireAdmin, async (req, res) => {

--- a/backend/supabase/bookings.sql
+++ b/backend/supabase/bookings.sql
@@ -1,0 +1,22 @@
+create table if not exists public.bookings (
+  id uuid primary key default gen_random_uuid(),
+  reference text not null unique,
+  service_category_id text not null,
+  service_category_name text not null,
+  package_id text not null,
+  package_name text not null,
+  package_price numeric(10, 2) not null default 0,
+  booking_date date not null,
+  booking_time text not null,
+  customer_first_name text not null,
+  customer_last_name text not null,
+  customer_email text not null,
+  customer_phone text not null,
+  vehicle_details text,
+  notes text,
+  status text not null default 'pending',
+  created_at timestamptz not null default now()
+);
+
+create index if not exists bookings_booking_date_idx on public.bookings (booking_date);
+create index if not exists bookings_customer_email_idx on public.bookings (customer_email);

--- a/royalautodetailing/src/components/BookingLayout.jsx
+++ b/royalautodetailing/src/components/BookingLayout.jsx
@@ -7,70 +7,129 @@ import Step5Information from "./Step5Information";
 import Step6Cart from "./Step6Cart";
 import Step7Confirmation from "./Step7Confirmation";
 
+function createInitialBookingState() {
+  return {
+    categoryId: "",
+    packageId: "",
+    bookingDate: "",
+    bookingTime: "",
+    firstName: "",
+    lastName: "",
+    email: "",
+    phone: "",
+    vehicleDetails: "",
+    notes: "",
+  };
+}
+
 export default function BookingLayout() {
-    const [step, setStep] = useState(1); // start from service for now
-    const steps = [
-        { title: "Category", caption: "Choose your detailing lane" },
-        { title: "Service", caption: "Pick the package intensity" },
-        { title: "Date & Time", caption: "Reserve a studio slot" },
-        { title: "Information", caption: "Driver and vehicle details" },
-        { title: "Cart", caption: "Review your selections" },
-        { title: "Confirmation", caption: "Lock in your booking" },
-    ];
-    const activeStep = steps[step - 1];
-    const progress = Math.round((step / steps.length) * 100);
+  const [step, setStep] = useState(1);
+  const [booking, setBooking] = useState(createInitialBookingState());
 
-    return (
-        <section className="booking-experience">
-            <div className="booking-orb booking-orb-one"></div>
-            <div className="booking-orb booking-orb-two"></div>
+  const steps = [
+    { title: "Category", caption: "Choose your detailing lane" },
+    { title: "Service", caption: "Pick the package intensity" },
+    { title: "Date & Time", caption: "Reserve a studio slot" },
+    { title: "Information", caption: "Driver and vehicle details" },
+    { title: "Cart", caption: "Review your selections" },
+    { title: "Confirmation", caption: "Lock in your booking" },
+  ];
 
-            <div className="container py-5">
-                <div className="booking-hero mb-4">
-                    <div>
-                        {/* <span className="booking-eyebrow">Royalz Premium Booking</span> */}
-                        <h4 className="booking-title">Welcome to Royalz Premium Booking</h4>
-                        <p className="booking-subtitle mb-0">
-                            Smooth step flow, cleaner visuals, and a premium booking atmosphere for customers ready to reserve.
-                        </p>
-                    </div>
+  const activeStep = steps[step - 1];
+  const progress = Math.round((step / steps.length) * 100);
 
-                    <div className="booking-hero-card">
-                        <div className="booking-hero-label">Live Progress</div>
-                        <div className="booking-hero-step">
-                            Step {step} of {steps.length}
-                        </div>
-                        <div className="booking-progress-track">
-                            <span style={{ width: `${progress}%` }}></span>
-                        </div>
-                        <div className="booking-hero-caption">{activeStep.caption}</div>
-                    </div>
-                </div>
+  const handleBookingChange = (partialUpdate) => {
+    setBooking((currentBooking) => ({
+      ...currentBooking,
+      ...partialUpdate,
+    }));
+  };
 
-                <div className="booking-shell">
-                    <div className="row g-0">
-                        <SidebarSteps step={step} steps={steps} />
+  const resetBooking = () => {
+    setBooking(createInitialBookingState());
+  };
 
-                        <div className="col-lg-8 col-xl-9 booking-stage-column">
-                            <div className="booking-stage">
-                                <div className="booking-stage-header">
-                                    <div>
-                                        <p className="booking-stage-kicker">Current Stage</p>
-                                    </div>
-                                    <div className="booking-stage-chip">{progress}% synced</div>
-                                </div>
+  return (
+    <section className="booking-experience">
+      <div className="booking-orb booking-orb-one"></div>
+      <div className="booking-orb booking-orb-two"></div>
 
-                                {step === 1 && <Step1Category setStep={setStep} />}
-                                {step === 2 && <Step3Package setStep={setStep} />}
-                                {step === 3 && <Step4DateTime setStep={setStep} />}
-                                {step === 4 && <Step5Information setStep={setStep} />}
-                                {step === 5 && <Step6Cart setStep={setStep} />}
-                                {step === 6 && <Step7Confirmation setStep={setStep} />}
-                            </div>
-                        </div>
-                    </div>
-                </div>
+      <div className="container py-5">
+        <div className="booking-hero mb-4">
+          <div>
+            <h4 className="booking-title">Welcome to Royalz Premium Booking</h4>
+            <p className="booking-subtitle mb-0">
+              Move through the booking steps, review the exact package you want,
+              and send a real reservation request to the Royalz team.
+            </p>
+          </div>
+
+          <div className="booking-hero-card">
+            <div className="booking-hero-label">Live Progress</div>
+            <div className="booking-hero-step">
+              Step {step} of {steps.length}
             </div>
-        </section>
-    );
+            <div className="booking-progress-track">
+              <span style={{ width: `${progress}%` }}></span>
+            </div>
+            <div className="booking-hero-caption">{activeStep.caption}</div>
+          </div>
+        </div>
+
+        <div className="booking-shell">
+          <div className="row g-0">
+            <SidebarSteps step={step} steps={steps} />
+
+            <div className="col-lg-8 col-xl-9 booking-stage-column">
+              <div className="booking-stage">
+                <div className="booking-stage-header">
+                  <div>
+                    <p className="booking-stage-kicker">Current Stage</p>
+                  </div>
+                  <div className="booking-stage-chip">{progress}% synced</div>
+                </div>
+
+                {step === 1 && (
+                  <Step1Category
+                    booking={booking}
+                    onBookingChange={handleBookingChange}
+                    setStep={setStep}
+                  />
+                )}
+                {step === 2 && (
+                  <Step3Package
+                    booking={booking}
+                    onBookingChange={handleBookingChange}
+                    setStep={setStep}
+                  />
+                )}
+                {step === 3 && (
+                  <Step4DateTime
+                    booking={booking}
+                    onBookingChange={handleBookingChange}
+                    setStep={setStep}
+                  />
+                )}
+                {step === 4 && (
+                  <Step5Information
+                    booking={booking}
+                    onBookingChange={handleBookingChange}
+                    setStep={setStep}
+                  />
+                )}
+                {step === 5 && <Step6Cart booking={booking} setStep={setStep} />}
+                {step === 6 && (
+                  <Step7Confirmation
+                    booking={booking}
+                    resetBooking={resetBooking}
+                    setStep={setStep}
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/royalautodetailing/src/components/ServiceCard.jsx
+++ b/royalautodetailing/src/components/ServiceCard.jsx
@@ -1,4 +1,4 @@
-export default function ServiceCard({ title, selected, onClick }) {
+export default function ServiceCard({ title, subtitle, selected, onClick }) {
   return (
     <div className="col-md-6 mb-4">
       <div
@@ -8,7 +8,7 @@ export default function ServiceCard({ title, selected, onClick }) {
         onClick={onClick}
       >
         <h5>{title}</h5>
-        <small>Auto Detailing</small>
+        <small>{subtitle || "Auto Detailing"}</small>
       </div>
     </div>
   );

--- a/royalautodetailing/src/components/Step1Category.jsx
+++ b/royalautodetailing/src/components/Step1Category.jsx
@@ -1,29 +1,32 @@
-import { useState } from "react";
 import ServiceCard from "./ServiceCard";
+import { bookingCatalog } from "../lib/bookingCatalog";
 
-export default function Step2Service({ setStep }) {
-  const [selected, setSelected] = useState(null);
-
-  const services = [
-    "Ceramic Coating",
-    "Tint",
-    "Wraps",
-    "Paint Protection Film (PPF)",
-  ];
+export default function Step1Category({ booking, onBookingChange, setStep }) {
+  const selectedCategory = booking.categoryId;
 
   return (
     <>
       <h4 className="mb-4" style={{ color: "#0f172a" }}>
-        Select Service
+        Select Service Category
       </h4>
+      <p className="text-muted mb-4">
+        Start by choosing the type of service you want to book. We will tailor the
+        next step packages to this selection.
+      </p>
 
       <div className="row">
-        {services.map((s, i) => (
+        {bookingCatalog.map((category) => (
           <ServiceCard
-            key={i}
-            title={s}
-            selected={selected === s}
-            onClick={() => setSelected(s)}
+            key={category.id}
+            title={category.name}
+            subtitle={category.shortLabel}
+            selected={selectedCategory === category.id}
+            onClick={() =>
+              onBookingChange({
+                categoryId: category.id,
+                packageId: "",
+              })
+            }
           />
         ))}
       </div>
@@ -31,7 +34,7 @@ export default function Step2Service({ setStep }) {
       <button
         className="btn btn-danger float-end"
         onClick={() => setStep(2)}
-        disabled={!selected}
+        disabled={!selectedCategory}
       >
         NEXT STEP
       </button>

--- a/royalautodetailing/src/components/Step3Package.jsx
+++ b/royalautodetailing/src/components/Step3Package.jsx
@@ -1,44 +1,45 @@
-import { useState } from "react";
+import { getCategoryById } from "../lib/bookingCatalog";
 
-export default function Step3Package({ setStep }) {
-  const [selected, setSelected] = useState(null);
-
-  const packages = [
-    { name: "Brand New Car", price: 499 },
-    { name: "First Step Paint Correction", price: 650 },
-    { name: "Second Step Paint Correction", price: 850 },
-  ];
+export default function Step3Package({ booking, onBookingChange, setStep }) {
+  const selectedCategory = getCategoryById(booking.categoryId);
+  const selectedPackageId = booking.packageId;
+  const packages = selectedCategory?.packages || [];
 
   return (
     <>
       <h4 className="mb-4">Select Package</h4>
+      <p className="text-muted mb-4">
+        {selectedCategory
+          ? `Available packages for ${selectedCategory.name}.`
+          : "Choose a service category first to view the available packages."}
+      </p>
 
-      {packages.map((pkg, i) => (
+      {packages.map((pkg) => (
         <div
-          key={i}
+          key={pkg.id}
           className={`package-card p-3 mb-3 ${
-            selected === pkg.name ? "active" : ""
+            selectedPackageId === pkg.id ? "active" : ""
           }`}
-          onClick={() => setSelected(pkg.name)}
+          onClick={() => onBookingChange({ packageId: pkg.id })}
         >
-          <div className="d-flex justify-content-between">
-            <span>{pkg.name}</span>
+          <div className="d-flex justify-content-between align-items-start gap-3">
+            <div>
+              <span>{pkg.name}</span>
+              <div className="small text-muted mt-1">{pkg.description}</div>
+            </div>
             <strong>${pkg.price}</strong>
           </div>
         </div>
       ))}
 
-      <button
-        className="btn btn-secondary me-2"
-        onClick={() => setStep(1)}
-      >
+      <button className="btn btn-secondary me-2" onClick={() => setStep(1)}>
         BACK
       </button>
 
       <button
         className="btn btn-danger float-end"
         onClick={() => setStep(3)}
-        disabled={!selected}
+        disabled={!selectedPackageId}
       >
         NEXT STEP
       </button>

--- a/royalautodetailing/src/components/Step4DateTime.jsx
+++ b/royalautodetailing/src/components/Step4DateTime.jsx
@@ -2,42 +2,60 @@ import { useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
 
-export default function Step4DateTime({ setStep }) {
-  const [selectedDate, setSelectedDate] = useState(new Date());
-  const [selectedTime, setSelectedTime] = useState(null);
+function toDateValue(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
 
+  return `${year}-${month}-${day}`;
+}
+
+export default function Step4DateTime({ booking, onBookingChange, setStep }) {
+  const initialDate = booking.bookingDate
+    ? new Date(`${booking.bookingDate}T12:00:00`)
+    : new Date();
+  const [selectedDate, setSelectedDate] = useState(initialDate);
   const timeSlots = ["09:00", "11:00", "13:00", "15:00"];
+
+  const handleDateChange = (date) => {
+    setSelectedDate(date);
+    onBookingChange({ bookingDate: toDateValue(date) });
+  };
+
+  const formattedDate = booking.bookingDate || toDateValue(selectedDate);
 
   return (
     <>
       <h4 className="mb-4">Select Date & Time</h4>
 
       <div className="row">
-        
-        {/* 📅 LEFT - CALENDAR */}
         <div className="col-md-6">
           <DatePicker
             selected={selectedDate}
-            onChange={(date) => setSelectedDate(date)}
+            onChange={handleDateChange}
             inline
             minDate={new Date()}
           />
         </div>
 
-        {/* ⏰ RIGHT - TIME */}
         <div className="col-md-6">
-          <h6 className="mb-3">
-            {selectedDate.toDateString()}
-          </h6>
+          <h6 className="mb-3">{selectedDate.toDateString()}</h6>
+          <p className="text-muted">
+            Choose a preferred studio time. We can follow up if the final slot
+            needs a small adjustment.
+          </p>
 
           <div className="d-flex flex-wrap gap-2">
-            {timeSlots.map((time, i) => (
+            {timeSlots.map((time) => (
               <button
-                key={i}
+                key={time}
+                type="button"
                 className={`time-slot ${
-                  selectedTime === time ? "active" : ""
+                  booking.bookingTime === time ? "active" : ""
                 }`}
-                onClick={() => setSelectedTime(time)}
+                onClick={() =>
+                  onBookingChange({ bookingDate: formattedDate, bookingTime: time })
+                }
               >
                 {time}
               </button>
@@ -46,19 +64,15 @@ export default function Step4DateTime({ setStep }) {
         </div>
       </div>
 
-      {/* BUTTONS */}
       <div className="mt-4">
-        <button
-          className="btn btn-secondary me-2"
-          onClick={() => setStep(2)}
-        >
+        <button className="btn btn-secondary me-2" onClick={() => setStep(2)}>
           BACK
         </button>
 
         <button
           className="btn btn-danger float-end"
           onClick={() => setStep(4)}
-          disabled={!selectedTime}
+          disabled={!booking.bookingDate || !booking.bookingTime}
         >
           NEXT STEP
         </button>

--- a/royalautodetailing/src/components/Step5Information.jsx
+++ b/royalautodetailing/src/components/Step5Information.jsx
@@ -1,85 +1,91 @@
-import { useState } from "react";
-
-export default function Step5Information({ setStep }) {
-  const [form, setForm] = useState({
-    firstName: "",
-    lastName: "",
-    email: "",
-    phone: "",
-  });
-
+export default function Step5Information({ booking, onBookingChange, setStep }) {
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, value } = e.target;
+    onBookingChange({ [name]: value });
   };
 
   const isValid =
-    form.firstName &&
-    form.lastName &&
-    form.email &&
-    form.phone;
+    booking.firstName &&
+    booking.lastName &&
+    booking.email &&
+    booking.phone;
 
   return (
     <>
       <h4 className="mb-4">Fill Information</h4>
 
       <div className="row">
-
-        {/* First Name */}
         <div className="col-md-6 mb-3">
           <label>First Name *</label>
           <input
             type="text"
             name="firstName"
             className="form-control"
-            value={form.firstName}
+            value={booking.firstName}
             onChange={handleChange}
           />
         </div>
 
-        {/* Last Name */}
         <div className="col-md-6 mb-3">
           <label>Last Name *</label>
           <input
             type="text"
             name="lastName"
             className="form-control"
-            value={form.lastName}
+            value={booking.lastName}
             onChange={handleChange}
           />
         </div>
 
-        {/* Email */}
         <div className="col-md-6 mb-3">
           <label>Email *</label>
           <input
             type="email"
             name="email"
             className="form-control"
-            value={form.email}
+            value={booking.email}
             onChange={handleChange}
           />
         </div>
 
-        {/* Phone */}
         <div className="col-md-6 mb-3">
           <label>Phone *</label>
           <input
             type="text"
             name="phone"
             className="form-control"
-            value={form.phone}
+            value={booking.phone}
             onChange={handleChange}
           />
         </div>
 
+        <div className="col-md-6 mb-3">
+          <label>Vehicle Details</label>
+          <input
+            type="text"
+            name="vehicleDetails"
+            className="form-control"
+            placeholder="Example: 2022 BMW X5, black"
+            value={booking.vehicleDetails}
+            onChange={handleChange}
+          />
+        </div>
+
+        <div className="col-md-6 mb-3">
+          <label>Additional Notes</label>
+          <input
+            type="text"
+            name="notes"
+            className="form-control"
+            placeholder="Anything we should know before the appointment?"
+            value={booking.notes}
+            onChange={handleChange}
+          />
+        </div>
       </div>
 
-      {/* BUTTONS */}
       <div className="mt-4">
-        <button
-          className="btn btn-secondary me-2"
-          onClick={() => setStep(3)}
-        >
+        <button className="btn btn-secondary me-2" onClick={() => setStep(3)}>
           BACK
         </button>
 

--- a/royalautodetailing/src/components/Step6Cart.jsx
+++ b/royalautodetailing/src/components/Step6Cart.jsx
@@ -1,54 +1,77 @@
-export default function Step6Cart({ setStep }) {
+import { getCategoryById, getPackageById } from "../lib/bookingCatalog";
+
+export default function Step6Cart({ booking, setStep }) {
+  const category = getCategoryById(booking.categoryId);
+  const selectedPackage = getPackageById(booking.categoryId, booking.packageId);
+
   return (
     <>
-      <h4 className="mb-4">Add to Cart</h4>
+      <h4 className="mb-4">Review Booking</h4>
 
       <div className="row">
-
-        {/* CART ITEM */}
         <div className="col-md-6">
           <div className="cart-card p-4">
-
-            <h5 className="mb-3">First Step Paint Correction</h5>
+            <h5 className="mb-3">{selectedPackage?.name || "Selected Package"}</h5>
 
             <p className="mb-1">
-              <strong>Service:</strong> Ceramic Coating
+              <strong>Service:</strong> {category?.name || "Not selected"}
             </p>
 
             <p className="mb-1">
-              <strong>Date & Time:</strong> 2026-03-25 / 09:00
+              <strong>Date & Time:</strong> {booking.bookingDate} / {booking.bookingTime}
             </p>
 
             <p className="mb-1">
+              <strong>Customer:</strong> {booking.firstName} {booking.lastName}
+            </p>
+
+            <p className="mb-1">
+              <strong>Email:</strong> {booking.email}
+            </p>
+
+            <p className="mb-1">
+              <strong>Phone:</strong> {booking.phone}
+            </p>
+
+            {booking.vehicleDetails && (
+              <p className="mb-1">
+                <strong>Vehicle:</strong> {booking.vehicleDetails}
+              </p>
+            )}
+
+            {booking.notes && (
+              <p className="mb-1">
+                <strong>Notes:</strong> {booking.notes}
+              </p>
+            )}
+
+            <p className="mb-1 mt-3">
               <strong>Amount:</strong>{" "}
-              <span className="text-success fw-bold">$650.00</span>
+              <span className="text-success fw-bold">
+                ${selectedPackage ? `${selectedPackage.price}.00` : "0.00"}
+              </span>
             </p>
-
           </div>
         </div>
 
+        <div className="col-md-6">
+          <div className="cart-card p-4 h-100">
+            <h5 className="mb-3">Before You Confirm</h5>
+            <ul className="mb-0 ps-3">
+              <li>We will review the request and reach out if the slot needs adjustment.</li>
+              <li>Pricing may change if the vehicle condition or scope differs from the request.</li>
+              <li>Your booking will be marked as pending until the team confirms it.</li>
+            </ul>
+          </div>
+        </div>
       </div>
 
-      {/* ADD MORE */}
       <div className="mt-4">
-        <button className="btn btn-outline-dark">
-          + Add New Booking
-        </button>
-      </div>
-
-      {/* BUTTONS */}
-      <div className="mt-4">
-        <button
-          className="btn btn-secondary me-2"
-          onClick={() => setStep(4)}
-        >
+        <button className="btn btn-secondary me-2" onClick={() => setStep(4)}>
           BACK
         </button>
 
-        <button
-          className="btn btn-danger float-end"
-          onClick={() => setStep(6)}
-        >
+        <button className="btn btn-danger float-end" onClick={() => setStep(6)}>
           NEXT STEP
         </button>
       </div>

--- a/royalautodetailing/src/components/Step7Confirmation.jsx
+++ b/royalautodetailing/src/components/Step7Confirmation.jsx
@@ -1,39 +1,71 @@
+import { useState } from "react";
 import Swal from "sweetalert2";
+import { apiPost } from "../lib/api";
+import { getCategoryById, getPackageById } from "../lib/bookingCatalog";
 
-export default function Step7Confirmation({ setStep }) {
-  const service = "First Step Paint Correction";
-  const price = 650;
+export default function Step7Confirmation({ booking, resetBooking, setStep }) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const serviceCategory = getCategoryById(booking.categoryId);
+  const selectedPackage = getPackageById(booking.categoryId, booking.packageId);
+  const price = selectedPackage?.price || 0;
   const discount = 0;
-
   const total = price - discount;
 
   const handleConfirmBooking = async () => {
-    await Swal.fire({
-      title: "Booking Confirmed",
-      html: `
-        <div class="booking-swal-copy">
-          <p>Your Royalz detailing session has been locked in successfully.</p>
-          <p>Thank you for choosing Royalz Auto Detailing.</p>
-        </div>
-      `,
-      icon: "success",
-      confirmButtonText: "View Booking",
-      showCancelButton: true,
-      cancelButtonText: "Close",
-      confirmButtonColor: "#d81324",
-      cancelButtonColor: "#0b2154",
-      background: "#ffffff",
-      color: "#111111",
-      customClass: {
-        popup: "booking-swal-popup",
-        title: "booking-swal-title",
-        confirmButton: "booking-swal-button",
-        cancelButton: "booking-swal-button booking-swal-button-secondary",
-      },
-      showClass: {
-        popup: "swal2-show booking-swal-show",
-      },
-    });
+    setIsSubmitting(true);
+
+    try {
+      const response = await apiPost("/api/bookings", {
+        categoryId: booking.categoryId,
+        categoryName: serviceCategory?.name || "",
+        packageId: booking.packageId,
+        packageName: selectedPackage?.name || "",
+        packagePrice: price,
+        bookingDate: booking.bookingDate,
+        bookingTime: booking.bookingTime,
+        firstName: booking.firstName,
+        lastName: booking.lastName,
+        email: booking.email,
+        phone: booking.phone,
+        vehicleDetails: booking.vehicleDetails,
+        notes: booking.notes,
+      });
+
+      await Swal.fire({
+        title: "Booking Request Sent",
+        html: `
+          <div class="booking-swal-copy">
+            <p>Your Royalz booking request has been submitted successfully.</p>
+            <p>Reference: <strong>${response.booking.reference}</strong></p>
+          </div>
+        `,
+        icon: "success",
+        confirmButtonText: "Done",
+        confirmButtonColor: "#d81324",
+        background: "#ffffff",
+        color: "#111111",
+        customClass: {
+          popup: "booking-swal-popup",
+          title: "booking-swal-title",
+          confirmButton: "booking-swal-button",
+        },
+        showClass: {
+          popup: "swal2-show booking-swal-show",
+        },
+      });
+
+      resetBooking();
+      setStep(1);
+    } catch (error) {
+      await Swal.fire({
+        title: "Unable To Submit Booking",
+        text: error.message || "Please try again in a moment.",
+        icon: "error",
+        confirmButtonColor: "#d81324",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -41,12 +73,16 @@ export default function Step7Confirmation({ setStep }) {
       <h4 className="mb-4">Confirm Details</h4>
 
       <div className="row">
-        {/* LEFT SUMMARY */}
         <div className="col-md-6">
           <div className="summary-card p-4">
             <div className="d-flex justify-content-between mb-2">
-              <span>{service}</span>
+              <span>{selectedPackage?.name || "Selected Package"}</span>
               <span className="fw-bold">${price}.00</span>
+            </div>
+
+            <div className="d-flex justify-content-between mb-3 text-muted">
+              <span>{serviceCategory?.name || "Selected Service"}</span>
+              <span>{booking.bookingDate} / {booking.bookingTime}</span>
             </div>
 
             <div className="d-flex justify-content-between mb-3 text-muted">
@@ -63,29 +99,25 @@ export default function Step7Confirmation({ setStep }) {
           </div>
         </div>
 
-        {/* RIGHT (ICON / EMPTY SPACE) */}
         <div className="col-md-6 d-flex align-items-center justify-content-center">
           <div className="confirm-box text-center">
             <i className="fa fa-check-circle fa-3x text-success mb-3"></i>
-            <p>Ready to confirm your booking</p>
+            <p>Ready to submit your booking request</p>
           </div>
         </div>
       </div>
 
-      {/* BUTTONS */}
       <div className="mt-4">
-        <button
-          className="btn btn-secondary me-2"
-          onClick={() => setStep(5)}
-        >
+        <button className="btn btn-secondary me-2" onClick={() => setStep(5)}>
           BACK
         </button>
 
         <button
           className="btn btn-danger float-end"
           onClick={handleConfirmBooking}
+          disabled={isSubmitting}
         >
-          CONFIRM BOOKING
+          {isSubmitting ? "SUBMITTING..." : "SUBMIT BOOKING"}
         </button>
       </div>
     </>

--- a/royalautodetailing/src/lib/bookingCatalog.js
+++ b/royalautodetailing/src/lib/bookingCatalog.js
@@ -1,0 +1,116 @@
+export const bookingCatalog = [
+  {
+    id: "ceramic-coating",
+    name: "Ceramic Coating",
+    shortLabel: "Long-term shine and paint protection",
+    packages: [
+      {
+        id: "brand-new-car",
+        name: "Brand New Car",
+        price: 499,
+        description: "Protection package for new or recently corrected vehicles.",
+      },
+      {
+        id: "first-step-paint-correction",
+        name: "First Step Paint Correction",
+        price: 650,
+        description: "Light correction plus ceramic protection for daily drivers.",
+      },
+      {
+        id: "second-step-paint-correction",
+        name: "Second Step Paint Correction",
+        price: 850,
+        description: "Deeper correction and gloss enhancement before coating.",
+      },
+    ],
+  },
+  {
+    id: "window-tinting",
+    name: "Window Tinting",
+    shortLabel: "Heat reduction, privacy, and a sharper exterior finish",
+    packages: [
+      {
+        id: "front-two-windows",
+        name: "Front Two Windows",
+        price: 199,
+        description: "Clean factory-style enhancement for the front doors.",
+      },
+      {
+        id: "full-sedan",
+        name: "Full Sedan Tint",
+        price: 349,
+        description: "Complete tint package for sedans and compact vehicles.",
+      },
+      {
+        id: "full-suv-truck",
+        name: "Full SUV / Truck Tint",
+        price: 429,
+        description: "Full tint coverage for larger vehicles and rear cargo glass.",
+      },
+    ],
+  },
+  {
+    id: "vehicle-wraps",
+    name: "Vehicle Wraps",
+    shortLabel: "Color change, branding, and premium wrap finishes",
+    packages: [
+      {
+        id: "roof-wrap",
+        name: "Roof Wrap",
+        price: 299,
+        description: "Accent wrap for a sharper two-tone look.",
+      },
+      {
+        id: "partial-wrap",
+        name: "Partial Wrap",
+        price: 899,
+        description: "Selected panels or branded sections with custom finish.",
+      },
+      {
+        id: "full-color-change-wrap",
+        name: "Full Color Change Wrap",
+        price: 2499,
+        description: "Full transformation package for maximum visual impact.",
+      },
+    ],
+  },
+  {
+    id: "paint-protection-film",
+    name: "Paint Protection Film (PPF)",
+    shortLabel: "Chip and scratch protection for high-impact surfaces",
+    packages: [
+      {
+        id: "partial-front",
+        name: "Partial Front Protection",
+        price: 799,
+        description: "Coverage for the highest-impact front paint surfaces.",
+      },
+      {
+        id: "full-front",
+        name: "Full Front Protection",
+        price: 1499,
+        description: "Bumper, hood, fenders, and mirror caps protected.",
+      },
+      {
+        id: "track-pack",
+        name: "Track Pack / Extended Coverage",
+        price: 1999,
+        description: "Expanded protection for premium and performance vehicles.",
+      },
+    ],
+  },
+];
+
+export function getCategoryById(categoryId) {
+  return bookingCatalog.find((category) => category.id === categoryId) || null;
+}
+
+export function getPackageById(categoryId, packageId) {
+  const category = getCategoryById(categoryId);
+
+  if (!category) {
+    return null;
+  }
+
+  return category.packages.find((pkg) => pkg.id === packageId) || null;
+}


### PR DESCRIPTION
Closes #22

## Summary
- replace the UI-only booking prototype with one shared booking draft across all booking steps
- add a real booking catalog for service categories and packages
- submit bookings to a new backend endpoint and persist them to Supabase
- add a Supabase bookings table schema and backend service role env configuration

## Testing
- npm run build
