### PR TITLE
Set up SEO and local business metadata for the public site

### DIFF
--- a/royalautodetailing/public/index.html
+++ b/royalautodetailing/public/index.html
@@ -2,10 +2,20 @@
 <html lang="en">
   <head>
       <meta charset="utf-8">
-    <title>Royalz Auto Detailing</title>
+    <title>Royalz Auto Detailing | Premium Auto Detailing in Halifax</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport">
-    <meta content="" name="keywords">
-    <meta content="" name="description">
+    <meta content="auto detailing halifax, ceramic coating halifax, window tint halifax, vehicle wraps halifax, paint protection film halifax" name="keywords">
+    <meta content="Royalz Auto Detailing provides premium auto detailing, ceramic coating, tint, wraps, and paint protection services in Halifax, Nova Scotia." name="description">
+    <meta property="og:title" content="Royalz Auto Detailing | Premium Auto Detailing in Halifax">
+    <meta property="og:description" content="Royalz Auto Detailing provides premium auto detailing, ceramic coating, tint, wraps, and paint protection services in Halifax, Nova Scotia.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="%PUBLIC_URL%/img/royallogo.png">
+    <meta property="og:site_name" content="Royalz Auto Detailing">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Royalz Auto Detailing | Premium Auto Detailing in Halifax">
+    <meta name="twitter:description" content="Royalz Auto Detailing provides premium auto detailing, ceramic coating, tint, wraps, and paint protection services in Halifax, Nova Scotia.">
+    <meta name="twitter:image" content="%PUBLIC_URL%/img/royallogo.png">
+    <link rel="canonical" href="https://www.royalzautodetailing.com/">
 
     <!-- Favicon -->
     <link href="%PUBLIC_URL%/img/royallogo.png" rel="icon" type="image/png">

--- a/royalautodetailing/src/components/Seo.jsx
+++ b/royalautodetailing/src/components/Seo.jsx
@@ -1,0 +1,99 @@
+import { useEffect } from "react";
+
+const DEFAULT_TITLE = "Royalz Auto Detailing | Premium Auto Detailing in Halifax";
+const DEFAULT_DESCRIPTION =
+  "Royalz Auto Detailing provides premium detailing, ceramic coating, tint, wraps, and vehicle protection services in Halifax, Nova Scotia.";
+const DEFAULT_SITE_NAME = "Royalz Auto Detailing";
+const DEFAULT_IMAGE = "/img/royallogo.png";
+
+function ensureMetaTag(selector, createAttributes) {
+  let element = document.head.querySelector(selector);
+
+  if (!element) {
+    element = document.createElement("meta");
+    Object.entries(createAttributes).forEach(([key, value]) => {
+      element.setAttribute(key, value);
+    });
+    document.head.appendChild(element);
+  }
+
+  return element;
+}
+
+function ensureLinkTag(selector, createAttributes) {
+  let element = document.head.querySelector(selector);
+
+  if (!element) {
+    element = document.createElement("link");
+    Object.entries(createAttributes).forEach(([key, value]) => {
+      element.setAttribute(key, value);
+    });
+    document.head.appendChild(element);
+  }
+
+  return element;
+}
+
+function updateMetaByName(name, content) {
+  const element = ensureMetaTag(`meta[name="${name}"]`, { name });
+  element.setAttribute("content", content);
+}
+
+function updateMetaByProperty(property, content) {
+  const element = ensureMetaTag(`meta[property="${property}"]`, { property });
+  element.setAttribute("content", content);
+}
+
+export default function Seo({
+  title,
+  description = DEFAULT_DESCRIPTION,
+  path = "/",
+  image = DEFAULT_IMAGE,
+  type = "website",
+  schema,
+}) {
+  useEffect(() => {
+    const resolvedTitle = title ? `${title} | ${DEFAULT_SITE_NAME}` : DEFAULT_TITLE;
+    const canonicalUrl = new URL(path, window.location.origin).toString();
+    const imageUrl = new URL(image, window.location.origin).toString();
+
+    document.title = resolvedTitle;
+    updateMetaByName("description", description);
+    updateMetaByProperty("og:title", resolvedTitle);
+    updateMetaByProperty("og:description", description);
+    updateMetaByProperty("og:type", type);
+    updateMetaByProperty("og:url", canonicalUrl);
+    updateMetaByProperty("og:image", imageUrl);
+    updateMetaByProperty("og:site_name", DEFAULT_SITE_NAME);
+    updateMetaByName("twitter:card", "summary_large_image");
+    updateMetaByName("twitter:title", resolvedTitle);
+    updateMetaByName("twitter:description", description);
+    updateMetaByName("twitter:image", imageUrl);
+
+    const canonical = ensureLinkTag('link[rel="canonical"]', { rel: "canonical" });
+    canonical.setAttribute("href", canonicalUrl);
+
+    let schemaTag = document.head.querySelector('script[data-seo-schema="page"]');
+
+    if (schema) {
+      if (!schemaTag) {
+        schemaTag = document.createElement("script");
+        schemaTag.type = "application/ld+json";
+        schemaTag.setAttribute("data-seo-schema", "page");
+        document.head.appendChild(schemaTag);
+      }
+
+      schemaTag.textContent = JSON.stringify(schema);
+    } else if (schemaTag) {
+      schemaTag.remove();
+    }
+
+    return () => {
+      if (schemaTag && !schema) {
+        schemaTag.remove();
+      }
+    };
+  }, [description, image, path, schema, title, type]);
+
+  return null;
+}

--- a/royalautodetailing/src/lib/seo.js
+++ b/royalautodetailing/src/lib/seo.js
@@ -1,0 +1,57 @@
+export const businessInfo = {
+  name: "Royalz Auto Detailing",
+  url: "https://www.royalzautodetailing.com",
+  image: "/img/royallogo.png",
+  telephone: "+1-782-882-0667",
+  alternateTelephone: "+1-902-412-2913",
+  address: {
+    streetAddress: "90 Horseshoe Lake Drive",
+    addressLocality: "Halifax",
+    addressRegion: "NS",
+    postalCode: "B3S 0B4",
+    addressCountry: "CA",
+  },
+  openingHours: [
+    "Mo-Fr 09:00-21:00",
+    "Sa-Su 09:00-12:00",
+  ],
+  sameAs: [
+    "https://www.google.com/maps/search/?api=1&query=90+Horseshoe+Lake+Drive+Halifax+NS+B3S+0B4",
+  ],
+};
+
+export function buildLocalBusinessSchema() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "AutoDetailing",
+    name: businessInfo.name,
+    url: businessInfo.url,
+    image: new URL(businessInfo.image, businessInfo.url).toString(),
+    telephone: businessInfo.telephone,
+    address: {
+      "@type": "PostalAddress",
+      ...businessInfo.address,
+    },
+    openingHours: businessInfo.openingHours,
+    sameAs: businessInfo.sameAs,
+  };
+}
+
+export function buildWebPageSchema({ title, description, path }) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    name: title,
+    description,
+    url: new URL(path, businessInfo.url).toString(),
+    isPartOf: {
+      "@type": "WebSite",
+      name: businessInfo.name,
+      url: businessInfo.url,
+    },
+    about: {
+      "@type": "AutoDetailing",
+      name: businessInfo.name,
+    },
+  };
+}

--- a/royalautodetailing/src/pages/About.jsx
+++ b/royalautodetailing/src/pages/About.jsx
@@ -1,6 +1,8 @@
 import { Link } from "react-router-dom";
+import Seo from "../components/Seo";
 import SiteFooter from "../components/SiteFooter";
 import SiteHeader from "../components/SiteHeader";
+import { buildLocalBusinessSchema, buildWebPageSchema } from "../lib/seo";
 import "./about.css";
 
 const values = [
@@ -29,8 +31,28 @@ const highlights = [
 ];
 
 export default function About() {
+  const title = "About Royalz Auto Detailing";
+  const description =
+    "Learn about Royalz Auto Detailing, our quality standards, and the premium detailing, tint, wraps, and protection services we provide in Halifax.";
+
   return (
     <>
+      <Seo
+        title={title}
+        description={description}
+        path="/about"
+        schema={{
+          "@context": "https://schema.org",
+          "@graph": [
+            buildLocalBusinessSchema(),
+            buildWebPageSchema({
+              title,
+              description,
+              path: "/about",
+            }),
+          ],
+        }}
+      />
       <SiteHeader activePage="about" />
 
       <section

--- a/royalautodetailing/src/pages/Booking.jsx
+++ b/royalautodetailing/src/pages/Booking.jsx
@@ -1,11 +1,33 @@
 import BookingLayout from "../components/BookingLayout";
+import Seo from "../components/Seo";
 import SiteFooter from "../components/SiteFooter";
 import SiteHeader from "../components/SiteHeader";
+import { buildLocalBusinessSchema, buildWebPageSchema } from "../lib/seo";
 import "./style.css";
 
 export default function Booking() {
+  const title = "Book Auto Detailing Services";
+  const description =
+    "Book ceramic coating, tint, wraps, and premium auto detailing services with Royalz Auto Detailing in Halifax.";
+
   return (
     <>
+      <Seo
+        title={title}
+        description={description}
+        path="/booking"
+        schema={{
+          "@context": "https://schema.org",
+          "@graph": [
+            buildLocalBusinessSchema(),
+            buildWebPageSchema({
+              title,
+              description,
+              path: "/booking",
+            }),
+          ],
+        }}
+      />
       <SiteHeader activePage="booking" />
       <BookingLayout />
       <SiteFooter />

--- a/royalautodetailing/src/pages/Contact.jsx
+++ b/royalautodetailing/src/pages/Contact.jsx
@@ -1,5 +1,7 @@
+import Seo from "../components/Seo";
 import SiteFooter from "../components/SiteFooter";
 import SiteHeader from "../components/SiteHeader";
+import { buildLocalBusinessSchema, buildWebPageSchema } from "../lib/seo";
 import "./contact.css";
 
 const contactCards = [
@@ -21,8 +23,28 @@ const contactCards = [
 ];
 
 export default function Contact() {
+  const title = "Contact Royalz Auto Detailing";
+  const description =
+    "Contact Royalz Auto Detailing in Halifax for bookings, service questions, pricing guidance, and premium vehicle care support.";
+
   return (
     <>
+      <Seo
+        title={title}
+        description={description}
+        path="/contact"
+        schema={{
+          "@context": "https://schema.org",
+          "@graph": [
+            buildLocalBusinessSchema(),
+            buildWebPageSchema({
+              title,
+              description,
+              path: "/contact",
+            }),
+          ],
+        }}
+      />
       <SiteHeader activePage="contact" />
 
       <section

--- a/royalautodetailing/src/pages/Index.jsx
+++ b/royalautodetailing/src/pages/Index.jsx
@@ -8,11 +8,17 @@ import "swiper/css/pagination";
 import "./home.css";
 import CountUp from "react-countup";
 import { useInView } from "react-intersection-observer";
+import Seo from "../components/Seo";
 import SiteFooter from "../components/SiteFooter";
 import SiteHeader from "../components/SiteHeader";
 import { useAdminAuth } from "../context/AdminAuthContext";
+import { buildLocalBusinessSchema, buildWebPageSchema } from "../lib/seo";
 
 function Index() {
+    const title = "Premium Auto Detailing in Halifax";
+    const description =
+        "Royalz Auto Detailing offers premium ceramic coating, tint, wraps, paint protection, and detailing services in Halifax, Nova Scotia.";
+
     const scrollToPricingPlan = () => {
         const pricingSection = document.getElementById("pricing-plan");
 
@@ -69,6 +75,22 @@ function Index() {
 
     return (
         <div>
+            <Seo
+                title={title}
+                description={description}
+                path="/"
+                schema={{
+                    "@context": "https://schema.org",
+                    "@graph": [
+                        buildLocalBusinessSchema(),
+                        buildWebPageSchema({
+                            title,
+                            description,
+                            path: "/",
+                        }),
+                    ],
+                }}
+            />
             {showAdminToast && (
                 <div
                     style={{


### PR DESCRIPTION
Closes #29

## Summary
- add reusable SEO helpers for page titles, descriptions, canonical URLs, and social tags
- add local business and webpage structured data for the public pages
- apply page-level metadata to the home, about, contact, and booking pages
- improve fallback branding and metadata in the public index.html

## Testing
- npm run build
