### PR TITLE
Add admin-managed booking availability

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -16,6 +16,16 @@ const ADMIN_EMAILS = new Set(
     .map((email) => email.trim().toLowerCase())
     .filter(Boolean)
 );
+const DEFAULT_TIME_SLOTS = ["09:00", "11:00", "13:00", "15:00"];
+
+function isValidDateValue(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return false;
+  }
+
+  const parsed = new Date(`${value}T00:00:00`);
+  return !Number.isNaN(parsed.getTime());
+}
 
 if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
   throw new Error("Missing SUPABASE_URL or SUPABASE_ANON_KEY in backend environment.");
@@ -121,6 +131,14 @@ function validateBookingPayload(payload) {
     return "Enter a valid email address.";
   }
 
+  if (!isValidDateValue(payload.bookingDate)) {
+    return "Choose a valid booking date.";
+  }
+
+  if (!DEFAULT_TIME_SLOTS.includes(payload.bookingTime)) {
+    return "Choose a valid booking time.";
+  }
+
   if (!Number.isFinite(payload.packagePrice) || payload.packagePrice < 0) {
     return "Package price must be a valid number.";
   }
@@ -164,6 +182,52 @@ async function upsertAdminSetting(key, value) {
   return data;
 }
 
+async function getDateAvailability(date) {
+  const [{ data: overrides, error: overridesError }, { data: bookings, error: bookingsError }] =
+    await Promise.all([
+      supabaseAdmin
+        .from("booking_availability")
+        .select("booking_time, is_available")
+        .eq("booking_date", date),
+      supabaseAdmin
+        .from("bookings")
+        .select("booking_time, status")
+        .eq("booking_date", date)
+        .in("status", ["pending", "confirmed", "completed"]),
+    ]);
+
+  if (overridesError) {
+    throw overridesError;
+  }
+
+  if (bookingsError) {
+    throw bookingsError;
+  }
+
+  const overrideMap = new Map(
+    (overrides || []).map((slot) => [slot.booking_time, slot.is_available])
+  );
+  const bookedSet = new Set((bookings || []).map((booking) => booking.booking_time));
+
+  const slots = DEFAULT_TIME_SLOTS.map((time) => {
+    const blockedByAdmin = overrideMap.get(time) === false;
+    const booked = bookedSet.has(time);
+
+    return {
+      time,
+      available: !blockedByAdmin && !booked,
+      blockedByAdmin,
+      booked,
+    };
+  });
+
+  return {
+    date,
+    slots,
+    availableSlots: slots.filter((slot) => slot.available).map((slot) => slot.time),
+  };
+}
+
 async function requireAdmin(req, res, next) {
   const accessToken = normalizeAuthToken(req.headers.authorization);
 
@@ -190,12 +254,47 @@ app.get("/health", (req, res) => {
   res.json({ ok: true, service: "royalz-render-backend" });
 });
 
+app.get("/api/booking-availability", async (req, res) => {
+  const date = `${req.query.date || ""}`.trim();
+
+  if (!date) {
+    return res.status(400).json({ error: "A booking date is required." });
+  }
+
+  if (!isValidDateValue(date)) {
+    return res.status(400).json({ error: "Enter a valid booking date." });
+  }
+
+  try {
+    const availability = await getDateAvailability(date);
+    return res.json(availability);
+  } catch (error) {
+    console.error("Unable to load booking availability.", error);
+    return res.status(500).json({ error: "Unable to load booking availability." });
+  }
+});
+
 app.post("/api/bookings", async (req, res) => {
   const booking = normalizeBookingPayload(req.body || {});
   const validationError = validateBookingPayload(booking);
 
   if (validationError) {
     return res.status(400).json({ error: validationError });
+  }
+
+  try {
+    const availability = await getDateAvailability(booking.bookingDate);
+
+    if (!availability.availableSlots.includes(booking.bookingTime)) {
+      return res.status(409).json({
+        error: "That date and time is no longer available. Please choose another slot.",
+      });
+    }
+  } catch (error) {
+    console.error("Unable to validate booking availability.", error);
+    return res.status(500).json({
+      error: "Unable to validate booking availability right now. Please try again.",
+    });
   }
 
   const reference = createBookingReference();
@@ -226,6 +325,13 @@ app.post("/api/bookings", async (req, res) => {
 
   if (error) {
     console.error("Unable to save booking.", error);
+
+    if (`${error.message || ""}`.toLowerCase().includes("duplicate")) {
+      return res.status(409).json({
+        error: "That date and time is already booked. Please choose another slot.",
+      });
+    }
+
     return res.status(500).json({
       error:
         "Unable to save the booking. Check the Supabase bookings table and backend service role configuration.",
@@ -299,6 +405,89 @@ app.get("/api/admin/dashboard", requireAdmin, async (req, res) => {
       error:
         "Unable to load dashboard data. Check the Supabase bookings and admin_settings tables.",
     });
+  }
+});
+
+app.get("/api/admin/availability", requireAdmin, async (req, res) => {
+  const date = `${req.query.date || ""}`.trim();
+
+  if (!date) {
+    return res.status(400).json({ error: "A booking date is required." });
+  }
+
+  if (!isValidDateValue(date)) {
+    return res.status(400).json({ error: "Enter a valid booking date." });
+  }
+
+  try {
+    const availability = await getDateAvailability(date);
+    return res.json(availability);
+  } catch (error) {
+    console.error("Unable to load admin availability.", error);
+    return res.status(500).json({ error: "Unable to load availability." });
+  }
+});
+
+app.put("/api/admin/availability", requireAdmin, async (req, res) => {
+  const date = `${req.body?.bookingDate || ""}`.trim();
+  const time = `${req.body?.bookingTime || ""}`.trim();
+  const isAvailable = Boolean(req.body?.isAvailable);
+
+  if (!date || !time) {
+    return res.status(400).json({ error: "Booking date and time are required." });
+  }
+
+  if (!isValidDateValue(date)) {
+    return res.status(400).json({ error: "Enter a valid booking date." });
+  }
+
+  if (!DEFAULT_TIME_SLOTS.includes(time)) {
+    return res.status(400).json({ error: "Invalid booking time." });
+  }
+
+  try {
+    const { data: bookedRow, error: bookingError } = await supabaseAdmin
+      .from("bookings")
+      .select("id")
+      .eq("booking_date", date)
+      .eq("booking_time", time)
+      .in("status", ["pending", "confirmed", "completed"])
+      .maybeSingle();
+
+    if (bookingError) {
+      throw bookingError;
+    }
+
+    if (bookedRow && isAvailable) {
+      return res.status(409).json({
+        error: "That slot is already booked. Update the booking status before reopening it.",
+      });
+    }
+
+    const { error } = await supabaseAdmin.from("booking_availability").upsert(
+      {
+        booking_date: date,
+        booking_time: time,
+        is_available: isAvailable,
+        updated_at: new Date().toISOString(),
+      },
+      {
+        onConflict: "booking_date,booking_time",
+      }
+    );
+
+    if (error) {
+      throw error;
+    }
+
+    const availability = await getDateAvailability(date);
+    return res.json({
+      message: "Availability updated.",
+      ...availability,
+    });
+  } catch (error) {
+    console.error("Unable to update availability.", error);
+    return res.status(500).json({ error: "Unable to update availability." });
   }
 });
 

--- a/backend/supabase/booking_availability.sql
+++ b/backend/supabase/booking_availability.sql
@@ -1,0 +1,7 @@
+create table if not exists public.booking_availability (
+  booking_date date not null,
+  booking_time text not null,
+  is_available boolean not null default true,
+  updated_at timestamptz not null default now(),
+  primary key (booking_date, booking_time)
+);

--- a/backend/supabase/bookings.sql
+++ b/backend/supabase/bookings.sql
@@ -20,3 +20,6 @@ create table if not exists public.bookings (
 
 create index if not exists bookings_booking_date_idx on public.bookings (booking_date);
 create index if not exists bookings_customer_email_idx on public.bookings (customer_email);
+create unique index if not exists bookings_active_slot_unique_idx
+on public.bookings (booking_date, booking_time)
+where status in ('pending', 'confirmed', 'completed');

--- a/royalautodetailing/src/components/Step4DateTime.jsx
+++ b/royalautodetailing/src/components/Step4DateTime.jsx
@@ -1,6 +1,8 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import DatePicker from "react-datepicker";
 import "react-datepicker/dist/react-datepicker.css";
+import { apiGet } from "../lib/api";
+import { bookingTimeSlots } from "../lib/bookingTimeSlots";
 
 function toDateValue(date) {
   const year = date.getFullYear();
@@ -15,14 +17,66 @@ export default function Step4DateTime({ booking, onBookingChange, setStep }) {
     ? new Date(`${booking.bookingDate}T12:00:00`)
     : new Date();
   const [selectedDate, setSelectedDate] = useState(initialDate);
-  const timeSlots = ["09:00", "11:00", "13:00", "15:00"];
+  const [availableSlots, setAvailableSlots] = useState(bookingTimeSlots);
+  const [loadingSlots, setLoadingSlots] = useState(false);
+  const [slotError, setSlotError] = useState("");
+
+  const formattedDate = useMemo(
+    () => booking.bookingDate || toDateValue(selectedDate),
+    [booking.bookingDate, selectedDate]
+  );
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadAvailability() {
+      if (!formattedDate) {
+        return;
+      }
+
+      setLoadingSlots(true);
+      setSlotError("");
+
+      try {
+        const response = await apiGet(
+          `/api/booking-availability?date=${encodeURIComponent(formattedDate)}`
+        );
+
+        if (!isMounted) {
+          return;
+        }
+
+        const nextAvailableSlots = response.availableSlots || [];
+        setAvailableSlots(nextAvailableSlots);
+
+        if (booking.bookingTime && !nextAvailableSlots.includes(booking.bookingTime)) {
+          onBookingChange({ bookingTime: "" });
+        }
+      } catch (error) {
+        if (!isMounted) {
+          return;
+        }
+
+        setSlotError(error.message);
+        setAvailableSlots([]);
+      } finally {
+        if (isMounted) {
+          setLoadingSlots(false);
+        }
+      }
+    }
+
+    loadAvailability();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [booking.bookingTime, formattedDate, onBookingChange]);
 
   const handleDateChange = (date) => {
     setSelectedDate(date);
-    onBookingChange({ bookingDate: toDateValue(date) });
+    onBookingChange({ bookingDate: toDateValue(date), bookingTime: "" });
   };
-
-  const formattedDate = booking.bookingDate || toDateValue(selectedDate);
 
   return (
     <>
@@ -41,12 +95,20 @@ export default function Step4DateTime({ booking, onBookingChange, setStep }) {
         <div className="col-md-6">
           <h6 className="mb-3">{selectedDate.toDateString()}</h6>
           <p className="text-muted">
-            Choose a preferred studio time. We can follow up if the final slot
-            needs a small adjustment.
+            Choose a preferred studio time. Only currently available slots are shown.
           </p>
 
+          {loadingSlots && <div className="alert alert-info py-2">Checking availability...</div>}
+          {slotError && <div className="alert alert-danger py-2">{slotError}</div>}
+
+          {!loadingSlots && !slotError && availableSlots.length === 0 && (
+            <div className="alert alert-warning py-2">
+              No time slots are available for this date. Please choose another date.
+            </div>
+          )}
+
           <div className="d-flex flex-wrap gap-2">
-            {timeSlots.map((time) => (
+            {availableSlots.map((time) => (
               <button
                 key={time}
                 type="button"

--- a/royalautodetailing/src/lib/bookingTimeSlots.js
+++ b/royalautodetailing/src/lib/bookingTimeSlots.js
@@ -1,0 +1,1 @@
+export const bookingTimeSlots = ["09:00", "11:00", "13:00", "15:00"];

--- a/royalautodetailing/src/pages/AdminDashboard.jsx
+++ b/royalautodetailing/src/pages/AdminDashboard.jsx
@@ -2,6 +2,35 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { apiGet, apiPut } from "../lib/api";
 import { useAdminAuth } from "../context/AdminAuthContext";
+import { bookingTimeSlots } from "../lib/bookingTimeSlots";
+
+function getTodayDateValue() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${day}`;
+}
+
+function formatSelectedDate(dateValue) {
+  if (!dateValue) {
+    return "Selected date";
+  }
+
+  const parsed = new Date(`${dateValue}T12:00:00`);
+
+  if (Number.isNaN(parsed.getTime())) {
+    return dateValue;
+  }
+
+  return parsed.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
 
 function formatStatusLabel(status) {
   if (!status) {
@@ -40,6 +69,18 @@ function AdminDashboard() {
   });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [availabilityDate, setAvailabilityDate] = useState(getTodayDateValue());
+  const [availabilitySlots, setAvailabilitySlots] = useState(
+    bookingTimeSlots.map((time) => ({
+      time,
+      available: true,
+      blockedByAdmin: false,
+      booked: false,
+    }))
+  );
+  const [availabilityLoading, setAvailabilityLoading] = useState(false);
+  const [availabilityError, setAvailabilityError] = useState("");
+  const [savingSlot, setSavingSlot] = useState("");
   const { adminUser, isAdmin, isLoading, session, signOutAdmin } = useAdminAuth();
 
   useEffect(() => {
@@ -96,6 +137,56 @@ function AdminDashboard() {
     };
   }, [isAdmin, isLoading, navigate, session?.access_token]);
 
+  useEffect(() => {
+    let isMounted = true;
+
+    async function loadAvailability() {
+      if (isLoading || !isAdmin || !session?.access_token || !availabilityDate) {
+        return;
+      }
+
+      setAvailabilityLoading(true);
+      setAvailabilityError("");
+
+      try {
+        const response = await apiGet(
+          `/api/admin/availability?date=${encodeURIComponent(availabilityDate)}`,
+          session.access_token
+        );
+
+        if (!isMounted) {
+          return;
+        }
+
+        setAvailabilitySlots(
+          response.slots ||
+            bookingTimeSlots.map((time) => ({
+              time,
+              available: true,
+              blockedByAdmin: false,
+              booked: false,
+            }))
+        );
+      } catch (apiError) {
+        if (!isMounted) {
+          return;
+        }
+
+        setAvailabilityError(apiError.message);
+      } finally {
+        if (isMounted) {
+          setAvailabilityLoading(false);
+        }
+      }
+    }
+
+    loadAvailability();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [availabilityDate, isAdmin, isLoading, session?.access_token]);
+
   const handleLogout = async () => {
     try {
       await signOutAdmin();
@@ -125,9 +216,37 @@ function AdminDashboard() {
     }
   };
 
+  const handleAvailabilityToggle = async (slot) => {
+    if (!session?.access_token) {
+      return;
+    }
+
+    setAvailabilityError("");
+    setSavingSlot(slot.time);
+
+    try {
+      const response = await apiPut(
+        "/api/admin/availability",
+        {
+          bookingDate: availabilityDate,
+          bookingTime: slot.time,
+          isAvailable: !slot.available,
+        },
+        session.access_token
+      );
+
+      setAvailabilitySlots(response.slots || []);
+    } catch (apiError) {
+      setAvailabilityError(apiError.message);
+    } finally {
+      setSavingSlot("");
+    }
+  };
+
   const menuItems = [
     { key: "dashboard", label: "Dashboard", icon: "fas fa-home" },
     { key: "recent", label: "Recent Bookings", icon: "fas fa-calendar-check" },
+    { key: "availability", label: "Availability", icon: "fas fa-clock" },
     { key: "email", label: "Email Recipient", icon: "fas fa-envelope" },
   ];
 
@@ -361,6 +480,94 @@ function AdminDashboard() {
                     Cancel
                   </button>
                 </form>
+              )}
+            </div>
+          )}
+          {activeMenu === "availability" && (
+            <div className="bg-white p-4 rounded shadow-sm mb-4">
+              <div className="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
+                <div>
+                  <h5 className="mb-1">Booking Availability</h5>
+                  <p className="text-muted mb-0">
+                    Block or reopen studio time slots. Booked slots stay reserved and stop
+                    showing in the public booking flow automatically.
+                  </p>
+                </div>
+                <div>
+                  <label htmlFor="availability-date" className="form-label small text-muted mb-1">
+                    Select date
+                  </label>
+                  <input
+                    id="availability-date"
+                    type="date"
+                    className="form-control"
+                    value={availabilityDate}
+                    min={getTodayDateValue()}
+                    onChange={(e) => setAvailabilityDate(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div className="alert alert-light border mb-4">
+                <strong>{formatSelectedDate(availabilityDate)}</strong>
+                <div className="small text-muted mt-1">
+                  Available slots stay bookable. Blocked slots are hidden on the website.
+                  Already-booked slots remain reserved until the booking status changes.
+                </div>
+              </div>
+
+              {availabilityError && <div className="alert alert-danger">{availabilityError}</div>}
+              {availabilityLoading && (
+                <div className="alert alert-info">Loading availability for this date...</div>
+              )}
+
+              {!availabilityLoading && (
+                <div className="row g-3">
+                  {availabilitySlots.map((slot) => {
+                    let stateLabel = "Available";
+                    let stateClass = "bg-success-subtle text-success";
+
+                    if (slot.booked) {
+                      stateLabel = "Booked";
+                      stateClass = "bg-secondary-subtle text-secondary";
+                    } else if (slot.blockedByAdmin) {
+                      stateLabel = "Blocked";
+                      stateClass = "bg-danger-subtle text-danger";
+                    }
+
+                    const buttonLabel = slot.available ? "Block Slot" : "Make Available";
+
+                    return (
+                      <div className="col-sm-6 col-xl-3" key={slot.time}>
+                        <div className="border rounded p-3 h-100 bg-light">
+                          <div className="d-flex justify-content-between align-items-start mb-2">
+                            <div>
+                              <div className="fw-semibold">{slot.time}</div>
+                              <div className="small text-muted">
+                                {slot.booked
+                                  ? "Reserved by an active booking"
+                                  : slot.blockedByAdmin
+                                    ? "Hidden from customer booking"
+                                    : "Visible in customer booking"}
+                              </div>
+                            </div>
+                            <span className={`badge ${stateClass}`}>{stateLabel}</span>
+                          </div>
+                          <button
+                            type="button"
+                            className={`btn btn-sm w-100 ${
+                              slot.available ? "btn-outline-danger" : "btn-outline-success"
+                            }`}
+                            onClick={() => handleAvailabilityToggle(slot)}
+                            disabled={slot.booked || savingSlot === slot.time}
+                          >
+                            {savingSlot === slot.time ? "Saving..." : buttonLabel}
+                          </button>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
               )}
             </div>
           )}


### PR DESCRIPTION
Closes #31

## Summary
- add admin-managed booking availability endpoints and slot conflict protection
- add a Supabase table for blocked or reopened booking slots
- prevent active bookings from double-booking the same date and time
- add an Availability menu to the admin dashboard for managing daily slots
- update the public booking flow to only show currently available time slots

## Testing
- npm run build
